### PR TITLE
Fixed new order title getting written into order description

### DIFF
--- a/tutorial-microservice-config-discovery/java-service/api/src/main/java/com/kumuluz/ee/nodejs/samples/tutorial/java/service/api/v1/rest/OrderResource.java
+++ b/tutorial-microservice-config-discovery/java-service/api/src/main/java/com/kumuluz/ee/nodejs/samples/tutorial/java/service/api/v1/rest/OrderResource.java
@@ -34,7 +34,7 @@ public class OrderResource {
 		Order order = new Order();
 		order.setCustomerId(newOrder.getCustomerId());
 		order.setTitle(newOrder.getTitle());
-		order.setDescription(newOrder.getTitle());
+		order.setDescription(newOrder.getDescription());
 		
 		ordersBean.createOrder(order);
 		


### PR DESCRIPTION
A very small bug I noticed working with the tutorial sample.